### PR TITLE
Ignore whitespace around equal sign

### DIFF
--- a/ini.el
+++ b/ini.el
@@ -43,7 +43,7 @@
 	      (setq section (match-string 1 l))
 	      (setq section-list nil)))
 	      ;; catch properties
-	      (if (string-match "^\\(.+\\)=\\(.+\\)$" l)
+	      (if (string-match "^\\([^\s\t]+\\)[\s\t]*=[\s\t]*\\(.+\\)$" l)
 		  (let ((property (match-string 1 l))
 			(value (match-string 2 l)))
 		    (progn 


### PR DESCRIPTION
Don't include whitespace before and after the equal sign in the key
and the value.  With this change,

    (ini-decode "foo = bar")

returns:

    (("foo" . "bar"))